### PR TITLE
Remove shell plugin

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -16,9 +16,3 @@ DefaultValue = //data:base_config
 DefaultValue = //tools:content_checker
 
 [Plugin "e2e"]
-
-[parse]
-preloadsubincludes = ///shell//build_defs:shell
-
-[Plugin "shell"]
-Target = //plugins:shell

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -5,9 +5,10 @@ please_tool(
     visibility = ["PUBLIC"],
 )
 
-sh_binary(
+filegroup(
     name = "content_checker",
-    main = "test_file_content.sh",
+    srcs = ["test_file_content.sh"],
+    binary = True,
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
The preload doesn't work properly - it seems to be intermittently failing, e.g. on https://github.com/please-build/go-rules/actions/runs/6362318684/job/17277275598?pr=159 which sometimes works for me locally seemingly dependent on state or some race (possibly about whether it ends up with the global one subincluded before this or not, although I _think_ the changes in that PR should have prevented that).

I imagine the underlying issue is that the plugin isn't defined in this repo but it's trying to globally preload it anyway. Regardless, it seems unnecessary for one trivial `sh_binary` where a filegroup should be totally fine.