### PR TITLE
Explicitly disable remote execution in e2e test repos

### DIFF
--- a/data/.plzconfig.e2e
+++ b/data/.plzconfig.e2e
@@ -1,3 +1,9 @@
 ; Set this so we don't pick up the test BUILD files in the main repo
 [parse]
 BuildFileName = BUILD_FILE
+
+; Disable remote execution in the test repo - this can be enabled by default via a global Please
+; config file that is visible within the test sandbox, and will prevent Please from loading the
+; plugin under test from a file:// URL.
+[remote]
+url =


### PR DESCRIPTION
Remote execution can be enabled by default via a configuration file in `/etc/please`, which is visible inside test sandboxes. It prevents Please from locating the plugin under test on the file system via a `file://` URL. Explicitly disable remote execution in the e2e Please config.

Fixes #4.